### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx


### PR DESCRIPTION
Potential fix for [https://github.com/jadolg/dockerhub-pull-limit-exporter/security/code-scanning/3](https://github.com/jadolg/dockerhub-pull-limit-exporter/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for each job. For the `docker` job, we will set `contents: read` as a minimal starting point, since the job does not appear to require write access to the repository contents. If additional permissions are required for specific actions, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
