### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/jadolg/dockerhub-pull-limit-exporter/security/code-scanning/1](https://github.com/jadolg/dockerhub-pull-limit-exporter/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `build` job in the workflow file. Based on the steps in the `build` job, it only requires `contents: read` permissions to perform its tasks. This change ensures that the `GITHUB_TOKEN` has the minimum required permissions, reducing the risk of unintended access or modifications.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
