### PR TITLE
Allow anonymous usage

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,5 +1,6 @@
 update_interval: 5m
 timeout: 20s
+allow_anonymous: true
 
 credentials:
   - username: user1

--- a/config.go
+++ b/config.go
@@ -13,15 +13,17 @@ type configuration struct {
 	UpdateInterval time.Duration `yaml:"update_interval"`
 	Timeout        time.Duration `yaml:"timeout"`
 	ConfigFiles    []string      `yaml:"config_files"`
+	AllowAnonymous bool          `yaml:"allow_anonymous"`
 }
 
 type credentials struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+	Anonymous bool   `json:"anonymous"`
 }
 
 func (c credentials) invalid() bool {
-	return c.Username == "" || c.Password == ""
+	return (c.Username == "" || c.Password == "") && !c.Anonymous
 }
 
 func getConfig(configFile string) (configuration, error) {
@@ -50,9 +52,15 @@ func getConfig(configFile string) (configuration, error) {
 		})
 	}
 
+	if c.AllowAnonymous {
+		c.Credentials = append(c.Credentials, credentials{
+			Anonymous: true,
+		})
+	}
+
 	for _, credential := range c.Credentials {
 		if credential.invalid() {
-			return configuration{}, fmt.Errorf("invalid credentials configuration detected for user %s", credential.Username)
+			return configuration{}, fmt.Errorf("invalid credentials configuration detected for user [%s]", credential.Username)
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+	"time"
+)
 
 func TestGetConfig(t *testing.T) {
 	config, err := getConfig("config.example.yaml")
@@ -11,8 +15,11 @@ func TestGetConfig(t *testing.T) {
 		t.Fatalf("Expected at least one credential, got none")
 	}
 	for _, cred := range config.Credentials {
-		if cred.Username == "" || cred.Password == "" {
+		if (cred.Username == "" || cred.Password == "") && !cred.Anonymous {
 			t.Fatalf("Expected non-empty username and password, got %s and %s", cred.Username, cred.Password)
+		}
+		if cred.Anonymous && (cred.Username != "" || cred.Password != "") {
+			t.Fatalf("Expected empty credentials for anonymous user but got username: %s and password %s instead", cred.Username, cred.Password)
 		}
 	}
 
@@ -33,5 +40,60 @@ func TestGetConfig(t *testing.T) {
 		if cred.Password != tt.password {
 			t.Fatalf("Expected password to be '%s', got '%s'", tt.password, cred.Password)
 		}
+	}
+}
+
+func TestInvalidCredentials(t *testing.T) {
+	cfg := configuration{
+		Credentials: []credentials{
+			{Username: "", Password: "", Anonymous: false},
+		},
+		UpdateInterval: time.Second,
+		Timeout:        time.Second,
+	}
+	_, err := func() (configuration, error) {
+		for _, credential := range cfg.Credentials {
+			if credential.invalid() {
+				return configuration{}, fmt.Errorf("invalid credentials configuration detected for user [%s]", credential.Username)
+			}
+		}
+		return cfg, nil
+	}()
+	if err == nil {
+		t.Fatal("expected error for invalid credentials, got nil")
+	}
+}
+
+func TestMissingUpdateInterval(t *testing.T) {
+	cfg := configuration{
+		Credentials:    []credentials{{Username: "user", Password: "pass"}},
+		UpdateInterval: 0,
+		Timeout:        time.Second,
+	}
+	_, err := func() (configuration, error) {
+		if cfg.UpdateInterval == 0 {
+			return configuration{}, fmt.Errorf("update interval must be set")
+		}
+		return cfg, nil
+	}()
+	if err == nil || err.Error() != "update interval must be set" {
+		t.Fatalf("expected error for missing update interval, got %v", err)
+	}
+}
+
+func TestMissingTimeout(t *testing.T) {
+	cfg := configuration{
+		Credentials:    []credentials{{Username: "user", Password: "pass"}},
+		UpdateInterval: time.Second,
+		Timeout:        0,
+	}
+	_, err := func() (configuration, error) {
+		if cfg.Timeout == 0 {
+			return configuration{}, fmt.Errorf("timeout must be set")
+		}
+		return cfg, nil
+	}()
+	if err == nil || err.Error() != "timeout must be set" {
+		t.Fatalf("expected error for missing timeout, got %v", err)
 	}
 }

--- a/dockerhub.go
+++ b/dockerhub.go
@@ -17,7 +17,9 @@ func getToken(username, password string, timeout time.Duration) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	req.SetBasicAuth(username, password)
+	if username != "" && password != "" {
+		req.SetBasicAuth(username, password)
+	}
 
 	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)

--- a/dockerhub_test.go
+++ b/dockerhub_test.go
@@ -48,6 +48,25 @@ func TestGetLimits(t *testing.T) {
 	t.Logf("Limit: %d, Remaining: %d, Source: %s", limit, remaining, source)
 }
 
+func TestGetLimitsNoUser(t *testing.T) {
+	token, err := getToken("", "", 10*time.Second)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	limit, remaining, limitWindow, remainingWindow, source, err := getLimits(token, 10*time.Second)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if limit == 0 || remaining == 0 || limitWindow == 0 || remainingWindow == 0 {
+		t.Fatalf("Expected limit and remaining to be non-zero, got %d and %d", limit, remaining)
+	}
+	if source == "" {
+		t.Fatalf("Expected source to be non-empty, got empty string")
+	}
+	t.Logf("Limit: %d, Remaining: %d, Source: %s", limit, remaining, source)
+}
+
 func TestParseLimits(t *testing.T) {
 	tests := []struct {
 		name                    string


### PR DESCRIPTION
Introduces a new configuration parameter `allow_anonymous` (disabled by default).
When this configuration is active, the exporter will also query with empty credentials which gives us the current limit for the host (unauthenticated) that's running the request.