### PR TITLE
Use source as user in metrics when no user is specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,10 +88,14 @@ func collectMetrics(credential credentials, timeout time.Duration) error {
 		return err
 	}
 
-	pullLimit.WithLabelValues(credential.Username, source).Set(float64(limit))
-	pullRemaining.WithLabelValues(credential.Username, source).Set(float64(remaining))
-	limitWindowSeconds.WithLabelValues(credential.Username, source).Set(float64(limitWindow))
-	remainingWindowSeconds.WithLabelValues(credential.Username, source).Set(float64(remainingWindow))
+	username := credential.Username
+	if credential.Anonymous {
+		username = source
+	}
+	pullLimit.WithLabelValues(username, source).Set(float64(limit))
+	pullRemaining.WithLabelValues(username, source).Set(float64(remaining))
+	limitWindowSeconds.WithLabelValues(username, source).Set(float64(limitWindow))
+	remainingWindowSeconds.WithLabelValues(username, source).Set(float64(remainingWindow))
 
 	return nil
 }


### PR DESCRIPTION
This gives a value to the user label so it's not missing and makes anonymous usage compatible with the already available Grafana dashboard.
It's also a bit more clear where the data comes from.