### PR TITLE
chore: update Go version to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine AS build
+FROM golang:1.26.3-alpine AS build
 
 RUN adduser --uid 1000 --disabled-password dockerhub-pull-limit-exporter-user
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module dockerhub-pull-limit-exporter
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/prometheus/client_golang v1.23.2


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.3**.

### Changes
- go.mod: go 1.26.2 → go 1.26.3
- Dockerfile: golang:1.26.2 → golang:1.26.3

_Automated PR by update-go-version.sh_